### PR TITLE
Fix result processing and temperature handling

### DIFF
--- a/src/ai.py
+++ b/src/ai.py
@@ -94,6 +94,10 @@ class OpenAIRater:
                 {"role": "user", "content": specific_user_prompt}
             ]
         }
+
+        ## Add temperature if provided
+        if temperature is not None:
+            request_params["temperature"] = temperature
         
         try:
             response = self.client.chat.completions.create(**request_params)

--- a/src/benchmark_rating.py
+++ b/src/benchmark_rating.py
@@ -214,8 +214,12 @@ class BenchmarkRunner:
                     result["student_id"] = student_id
 
                 ## Ensure each value is a string
-                for key in result:
-                    result[key] = str(json.dumps(result[key]))
+                for key, value in result.items():
+                    ## Store nested structures as JSON strings
+                    if isinstance(value, (dict, list)):
+                        result[key] = json.dumps(value, ensure_ascii=False)
+                    else:
+                        result[key] = str(value)
                     
                 results.append(result)
                 

--- a/src/config.py
+++ b/src/config.py
@@ -314,7 +314,9 @@ class Config:
             raise ValueError(f"Number of runs must be at least 1, got {self.num_runs}")
 
         if self.limit < 0:
-            raise ValueError(f"Limit of students text must be at least 1 or 0 for no limit, got {self.num_runs}")
+            raise ValueError(
+                f"Limit of students text must be at least 1 or 0 for no limit, got {self.limit}"
+            )
             
         if self.max_workers < 1:
             raise ValueError(f"Maximum workers must be at least 1, got {self.max_workers}")


### PR DESCRIPTION
## Summary
- fix OpenAI rater to pass temperature parameter
- correctly stringify benchmark results
- fix limit validation message in config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684023be2fa0832e8cedff0d927cbf77