### PR TITLE
Remove obsolete config keys

### DIFF
--- a/src/benchmark_rating.py
+++ b/src/benchmark_rating.py
@@ -186,14 +186,13 @@ class BenchmarkRunner:
         
         ## Get configuration for this service
         model = getattr(self.config, f"model_{service}")
-        comment = getattr(self.config, f"comment_{service}")
         temperature = self.config.temperature if self.config.use_temperature else None
-        
+
         ## Define output file path
         temp_str = f"temp{self.config.temperature}" if self.config.use_temperature else "noTemp"
         output_file = os.path.join(
-            output_dir, 
-            f"data_{service}_{model}_{temp_str}_{comment}_run{run_num}.csv"
+            output_dir,
+            f"data_{service}_{model}_{temp_str}_run{run_num}.csv"
         )
         
         ## Process function for individual texts
@@ -215,7 +214,7 @@ class BenchmarkRunner:
             ## Save raw response
             raw_output_file = os.path.join(
                 output_dir,
-                f"raw_{service}_{model}_{temp_str}_{comment}_run{run_num}_{student_id}.json"
+                f"raw_{service}_{model}_{temp_str}_run{run_num}_{student_id}.json"
             )
             ResultsManager.save_raw_response(result, raw_output_file)
 
@@ -300,14 +299,13 @@ class BenchmarkRunner:
 
         ## Get configuration for this service
         model = getattr(self.config, f"model_{service}")
-        comment = getattr(self.config, f"comment_{service}")
         temperature = self.config.temperature if self.config.use_temperature else None
 
         ## Define output file path
         temp_str = f"temp{self.config.temperature}" if self.config.use_temperature else "noTemp"
         output_file = os.path.join(
-            output_dir, 
-            f"data_{service}_{model}_{temp_str}_{comment}_batch_run{run_num}.csv"
+            output_dir,
+            f"data_{service}_{model}_{temp_str}_batch_run{run_num}.csv"
         )
 
         ## Create batch directory
@@ -352,7 +350,7 @@ class BenchmarkRunner:
                     # Save raw response
                     raw_output_file = os.path.join(
                         output_dir,
-                        f"raw_{service}_{model}_{temp_str}_{comment}_batch_run{run_num}_{student_id}.json"
+                        f"raw_{service}_{model}_{temp_str}_batch_run{run_num}_{student_id}.json"
                     )
                     ResultsManager.save_raw_response(response_text, raw_output_file)
 

--- a/src/config.py
+++ b/src/config.py
@@ -48,8 +48,6 @@ class ConfigSchema:
         "api_claude": {"type": str, "required": False, "default": ""},
         "api_mistral": {"type": str, "required": False, "default": ""},
         "org_openai": {"type": str, "required": False, "default": ""},
-        "url_openai": {"type": str, "required": False, "default": "https://api.openai.com/v1/chat/completions"},
-        "url_claude": {"type": str, "required": False, "default": "https://api.anthropic.com/v1/messages"},
         
         # Generation settings
         "temperature": {"type": float, "required": False, "default": 0.7, "min": 0.0, "max": 2.0},
@@ -60,10 +58,6 @@ class ConfigSchema:
         "model_claude": {"type": str, "required": False, "default": "claude-3-7-sonnet-20250219"},
         "model_mistral": {"type": str, "required": False, "default": "mistral-large-2411"},
         
-        # Run comments (used in filenames)
-        "comment_openai": {"type": str, "required": False, "default": "Run"},
-        "comment_claude": {"type": str, "required": False, "default": "Run"},
-        "comment_mistral": {"type": str, "required": False, "default": "Run"},
         
         # Service toggles
         "use_openai": {"type": bool, "required": False, "default": False},
@@ -218,9 +212,6 @@ class ConfigManager:
         'openai_model': 'model_openai',
         'claude_model': 'model_claude',
         'mistral_model': 'model_mistral',
-        'openai_comment': 'comment_openai',
-        'claude_comment': 'comment_claude',
-        'mistral_comment': 'comment_mistral',
     }
     
     @classmethod
@@ -498,10 +489,6 @@ class Config:
         self.api_claude = config.get('api_claude', '')
         self.api_mistral = config.get('api_mistral', '')
         
-        # API URLs
-        self.url_openai = config.get('url_openai', 'https://api.openai.com/v1/chat/completions')
-        self.url_claude = config.get('url_claude', 'https://api.anthropic.com/v1/messages')
-        
         # Organization IDs
         self.org_openai = config.get('org_openai', '')
         
@@ -513,11 +500,6 @@ class Config:
         self.model_openai = config.get('model_openai', 'gpt-4o-2024-11-20')
         self.model_claude = config.get('model_claude', 'claude-3-7-sonnet-20250219')
         self.model_mistral = config.get('model_mistral', 'mistral-large-2411')
-        
-        # Comments for file naming
-        self.comment_openai = config.get('comment_openai', 'Run')
-        self.comment_claude = config.get('comment_claude', 'Run')
-        self.comment_mistral = config.get('comment_mistral', 'Run')
         
         # Input/output settings - use standardized names
         self.input_corpus_path = config.get('input_corpus_path', '')


### PR DESCRIPTION
## Summary
- clean up configuration schema
- drop support for `url_*` and `comment_*` options
- simplify benchmark output file names

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68761aacf1b8832eabb91b3cb5442a93